### PR TITLE
fix: improve theme dropdown visibility in light mode

### DIFF
--- a/src/components/ThemeSelector.svelte
+++ b/src/components/ThemeSelector.svelte
@@ -98,7 +98,6 @@
     --item-height: 1.5em;
 
     --font-size: 1em;
-    color: var(--text-color);
 
     --chevron-width: 100%;
     --chevron-icon-width: 1em;
@@ -111,12 +110,8 @@
     --list-background: var(--background-color);
     --item-hover-bg: var(--line-focus-background-color);
     --selected-item-bg: var(--line-focus-background-color);
-    --item-is-active-bg: var(--line-focus-background-color);
-
-    --item-color: var(--text-color);
-    --item-hover-color: var(--text-color);
-    --item-is-active-color: var(--text-color);
-    --item-active-color: var(--text-color);
+    --item-is-active-bg: var(--text-color);
+    --item-is-active-color:var(--background-color);
 
     --border: thin solid var(--text-color);
     --border-focused: thin solid var(--text-color);


### PR DESCRIPTION

Fixes #26

The theme dropdown options were difficult to see when using light themes (e.g., Atom One) due to insufficient contrast between the text and background.

This change ensures proper visibility by adjusting the styling of the theme selector so that the text remains readable in light mode.

Tested locally to confirm the dropdown options are clearly visible in both light and dark themes.

Before:
<img width="277" height="237" alt="image" src="https://github.com/user-attachments/assets/ef49ea07-bbe4-4f5a-9e0e-20fed603a4b3" />
After:
<img width="459" height="300" alt="image" src="https://github.com/user-attachments/assets/f6e9e8a9-2ac9-4360-978d-8b343181998f" />

